### PR TITLE
Remove override on createJSModules. Required for RN 0.57.0

### DIFF
--- a/android/src/main/java/ca/bigdata/voice/dtmf/BigDataDTMFPackage.java
+++ b/android/src/main/java/ca/bigdata/voice/dtmf/BigDataDTMFPackage.java
@@ -16,7 +16,6 @@ public class BigDataDTMFPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new BigDataDTMFModule(reactContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
Android throws an error about Override on createJSModules. This is a breaking change upgrading to RN 0.57.0. Just removed the Override
https://github.com/facebook/react-native/releases/tag/v0.47.0