### PR TITLE
fix react-native dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "author": "Luc Belliveau",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.41.2"
+    "react-native": ">=0.41.2"
   }
 }


### PR DESCRIPTION
Using the Caret shorthand does not work when the major version number is `0` (see below). This means the package cannot be installed unless you have exactly react-native `0.41.2`. This PR changes this so any version above `0.41.2` is allowed.

> Complications arise with the use of 0.x.x versions, where the rules get messy due to the nature of the special 0 major version number in the semver specification. The major version 0 is supposed to be reserved for "initial development", where "anything may change at any time", so the "patch" and "minor, non-breaking changes" essentially have no meaning.

>Unlike ~, the ^ operator with a major version of 0 is essentially a no-op, in that it translates to exactly that version rather than a full range. So "^0.2.3" is equal to just "0.2.3" and no more.

https://nodesource.com/blog/semver-a-primer/